### PR TITLE
Correcting typo for debug message

### DIFF
--- a/Moose Development/Moose/Wrapper/Marker.lua
+++ b/Moose Development/Moose/Wrapper/Marker.lua
@@ -646,7 +646,7 @@ function MARKER:OnEventMarkRemoved(EventData)
 
     local MarkID=EventData.MarkID
 
-    self:T3(self.lid..string.format("Captured event MarkAdded for Mark ID=%s", tostring(MarkID)))
+    self:T3(self.lid..string.format("Captured event MarkRemoved for Mark ID=%s", tostring(MarkID)))
 
     if MarkID==self.mid then
 


### PR DESCRIPTION
This must have been a small copy/paste error. The debug message is located in the following definition.
```
function MARKER:OnEventMarkRemoved(EventData)
```