### PR TITLE
Synchronize Text with Wrapper State

### DIFF
--- a/Moose Development/Moose/Wrapper/Marker.lua
+++ b/Moose Development/Moose/Wrapper/Marker.lua
@@ -673,9 +673,9 @@ function MARKER:OnEventMarkChange(EventData)
 
     if MarkID==self.mid then
 
-      self:Changed(EventData)
+      self.text=tostring(EventData.MarkText)
 
-      self:TextChanged(tostring(EventData.MarkText))
+      self:Changed(EventData)
 
     end
 


### PR DESCRIPTION
This must have been a small copy/paste error. The debug message is located in the following definition.
```
function MARKER:OnEventMarkRemoved(EventData)
```